### PR TITLE
fix: contents-page hierarchy, and sidenotes overlapping the footer

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -322,6 +322,23 @@ hr {
   color: var(--ink);
 }
 
+/* A subsection (h3) nests under the part (h2) above it — same flat list,
+ * but indented, smaller and quieter, so the hierarchy a reader would see in
+ * the document's own contents page survives onto this one. */
+.report-list li.sub {
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--rule);
+}
+
+.report-list li.sub a {
+  padding-block: 1.25rem;
+}
+
+.report-list .title.sub {
+  font-size: 1.1rem;
+  color: var(--body);
+}
+
 /* ---------- report page ---------- */
 
 .report-header {
@@ -544,6 +561,13 @@ hr {
      * once the notes are hanging off the right of it. */
     margin-left: max(0px, calc(50% - (var(--measure) + var(--sidenote-width) + var(--sidenote-gap)) / 2));
     margin-right: 0;
+    /* A floated sidenote longer than the paragraph beside it otherwise falls
+     * outside .prose's own height — the box ends where the last unfloated
+     * line does, and the section nav and footer render on top of the note
+     * that is still visually hanging below. flow-root makes .prose's box
+     * contain its floated children without clipping their negative-margin
+     * overflow into the right-hand column, unlike overflow: hidden. */
+    display: flow-root;
   }
 
   .sidenote {

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -69,11 +69,20 @@ if (firstReportId) {
   const report = await page.evaluate(() => {
     const p1 = document.querySelector(".prose p[id]");
     const prose = document.querySelector(".prose");
+    const notes = [...document.querySelectorAll(".sidenote")];
+    const proseBottom = prose ? prose.getBoundingClientRect().bottom : 0;
+    // A sidenote longer than the paragraph beside it floats past wherever an
+    // uncleared .prose box would otherwise end — the section nav and footer
+    // would then render on top of it. See PROGRESS.md, 2026-08-09.
+    const maxNoteBottom = notes.reduce(
+      (max, note) => Math.max(max, note.getBoundingClientRect().bottom),
+      0
+    );
     return {
       hasP1: Boolean(p1),
       hasPermalink: Boolean(p1 && p1.querySelector("a.permalink")),
       positionalIds: document.querySelectorAll('.prose p[id^="p-"]').length,
-      sidenotes: document.querySelectorAll(".sidenote").length,
+      sidenotes: notes.length,
       pageMarkers: document.querySelectorAll(".page-marker").length,
       firstId: p1 ? p1.id : "",
       proseFont: prose ? getComputedStyle(prose).fontFamily : "",
@@ -86,6 +95,7 @@ if (firstReportId) {
         : 0,
       paragraphs: document.querySelectorAll(".prose p[id]").length,
       frontMatterLeaked: document.body.innerText.includes('title: "'),
+      proseContainsNotes: proseBottom >= maxNoteBottom - 1,
     };
   });
 
@@ -105,6 +115,11 @@ if (firstReportId) {
   check(/[a-z]/.test(report.firstId), "paragraph ids are text-derived", report.firstId);
   check(report.sidenotes > 0, "sidenotes are rendered", String(report.sidenotes));
   check(report.pageMarkers > 0, "printed page markers are rendered", String(report.pageMarkers));
+  check(
+    report.proseContainsNotes,
+    "prose contains its longest sidenote (no footer overlap)",
+    String(report.proseContainsNotes)
+  );
 
   // :target highlight actually applies
   await page.goto(`${base}/reports/${firstReportId}/full#${report.firstId}`, {

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -6,6 +6,13 @@ export type Section = {
   html: string;
   /** First printed page the section covers, for the contents listing. */
   page?: string;
+  /**
+   * The heading level the section split on — 2 for a top-level part, 3 for a
+   * subsection. Front matter (no heading) counts as top-level. The contents
+   * listing uses this to show which sections nest under which, rather than a
+   * flat list a reader has to reverse-engineer from title-casing.
+   */
+  level: 2 | 3;
 };
 
 /**
@@ -49,6 +56,7 @@ export function splitSections(html: string, minChars = MIN_SECTION_CHARS): Secti
       title,
       html: part,
       page: part.match(/id="page-(\d+)"/)?.[1],
+      level: heading ? (Number(heading[1]) as 2 | 3) : 2,
     });
   }
 

--- a/src/templates/section.ts
+++ b/src/templates/section.ts
@@ -22,15 +22,16 @@ export function renderReportOverview(
   const byline = [meta.authors, meta.published_at].filter(Boolean).join(" · ");
 
   const items = sections
-    .map(
-      (section) => `<li>
+    .map((section) => {
+      const isSub = section.level === 3;
+      return `<li${isSub ? ' class="sub"' : ""}>
         <a href="/reports/${escapeHtml(meta.id ?? "")}/${escapeHtml(section.slug)}">
-          <span class="title serif">${escapeHtml(section.title)}</span>
+          <span class="title serif${isSub ? " sub" : ""}">${escapeHtml(section.title)}</span>
           ${section.page ? `<span class="meta mono">p. ${escapeHtml(section.page)}</span>` : "<span></span>"}
           <span class="cue mono">Read →</span>
         </a>
-      </li>`
-    )
+      </li>`;
+    })
     .join("");
 
   const body = `

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -232,4 +232,17 @@ describe("splitSections", () => {
     const sections = splitSections(html, 0);
     expect(sections[0].title).toBe("Moody's & Standard & Poor's");
   });
+
+  it("records the heading level a section split on, so the contents page can nest them", async () => {
+    const { splitSections } = await import("../src/lib/sections");
+    const html = renderMarkdown(
+      "Front matter here.\n\n## A Part\n\nBody.\n\n### A Subsection\n\nMore body."
+    );
+    const sections = splitSections(html, 0);
+    expect(sections.map((s) => [s.title, s.level])).toEqual([
+      ["Front matter", 2],
+      ["A Part", 2],
+      ["A Subsection", 3],
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Two rendering bugs Rufus reported on the live site, both root-caused before fixing:

**1. Contents page had no visual hierarchy** — every section (top-level parts and their subsections) rendered as an identical flat list row. Root cause: `splitSections` matched a section's heading level (h2 vs h3) but never stored it on the `Section` object, so the template had no way to tell them apart. `Section` now carries a `level`, and the contents template indents + de-emphasises subsections.

**2. A long sidenote could overlap the section nav and footer** — reported at https://reportsthatmatter.org/reports/jack-smith-vol1/mr-trumps-fraudulent-elector-plan. Root cause, confirmed by measuring the DOM (not guessed): `.sidenote` is `float: right` inside `.prose`, and `.prose` never clears its floats. On that page, `.prose`'s box ended ~2000px short of where its longest sidenote actually finished, and the nav/footer that follow in the DOM rendered on top of it. Fixed with `display: flow-root` on `.prose` at the sidenote breakpoint — contains the floats without clipping their negative-margin overflow the way `overflow: hidden` would. Added a geometry-based check to `scripts/e2e.mjs` so this can't silently reappear.

A deeper design question — full-height sidenotes drift out of alignment with their paragraph over a long citation-heavy page, and there's no perfect fix — is intentionally **not** addressed here. Rufus asked for that to be a dedicated research issue rather than a quick patch: **#80**.

## Before / after

**Contents page** — subsections now indent under their part instead of reading as one flat list.

**Sidenote overlap** — before, `.prose`'s box ended at the same height as `.section-nav`'s top despite a sidenote still rendering ~2000px further down; after, `.prose` correctly contains it and nav/footer render below.

## Test plan

- [x] `pnpm vitest run` — 149 passed, including a new test asserting `Section.level` for h2/h3
- [x] `./scripts/verify.sh` — full green, including a new browser check: prose's bottom edge reaches at least as far as its longest sidenote
- [x] Reproduced both bugs locally first (DOM geometry measurement + screenshots) before writing the fix, confirmed the exact numbers moved from broken to fixed
- [x] Checked mobile width (390px) — indentation and sidenote toggle behaviour unaffected, this only touches the ≥68rem desktop breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRyy83p1fxZ3HaaCXNJPiP